### PR TITLE
Replace .env var validation with Github token resolver func

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,15 +1,16 @@
-import { TOKEN } from "../config/env";
+import { resolveGithubToken } from "../config/env";
+import { resolveGitContext } from "../utils/gitContext";
 import { GithubService } from "../services/githubService";
 import { prompt } from "../utils/prompt";
 import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/gitUtils";
-import { resolveGitContext } from "../utils/gitContext";
 
 async function createCommand(): Promise<void> {
     try {
         const context = resolveGitContext();
+        const token = resolveGithubToken();
         
         const github = new GithubService({
-            token: TOKEN, 
+            token: token, 
             owner: context.owner, 
             repo: context.repo
         });

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,13 +1,15 @@
-import { TOKEN } from "../config/env";
+import { resolveGithubToken } from "../config/env";
 import { resolveGitContext } from "../utils/gitContext";
 import { GithubService } from "../services/githubService";
 import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/gitUtils";
 
 async function listCommand(): Promise<void> {
     try {
-        const { owner, repo } = resolveGitContext();
+        const { owner, repo } = resolveGitContext();    
+        const token = resolveGithubToken();
+        
         const github = new GithubService({
-            token: TOKEN, 
+            token: token, 
             owner: owner, 
             repo: repo
         });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,16 +1,11 @@
 import { configDotenv } from "dotenv";
 configDotenv({quiet: true});
 
-// fetch env vars
-function fetchEnvVar(name: string): string {
-    const value = process.env[name];
-
-    if (!value) {
-        console.log(`Missing required environment variable: ${name}`);
-        process.exit(1)
+// get github token env var
+export function resolveGithubToken(): string {
+    if (process.env.GITHUB_TOKEN) {
+        return process.env.GITHUB_TOKEN
     }
 
-    return value;
+    throw new Error("Missing Github Token Config. Please run 'pr auth login' to authenticate")
 }
-
-export const TOKEN = fetchEnvVar('TOKEN');


### PR DESCRIPTION
removed previous function to fetch env vars with a new resolveGithubToken meaning token is resolved at command time rather than import time