### PR TITLE
Display pull request data from getPullRequest via pull number

### DIFF
--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -1,5 +1,47 @@
-function getCommand() {
-    console.log('get')
+import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/gitUtils.js"
+import { logError, logWarn, logText } from "../utils/logger.js"
+import { GithubService } from "../services/githubService.js";
+import { resolveGitContext } from "../utils/gitContext.js";
+import { resolveGithubToken } from "../config/env.js";
+
+async function getCommand(pullNumber: number): Promise<void> {
+    try {
+        const context = resolveGitContext();
+        const token = resolveGithubToken();
+
+        const github = new GithubService({
+            token: token,
+            owner: context.owner,
+            repo: context.repo,
+        });
+
+        const pullRequest = await github.getPullRequest(pullNumber);
+
+        // Display pull request data in clean format
+        logWarn(`Pull Request #${pullRequest.number}  ${pullRequest.html_url}`, { bold: true });
+        console.log(`Author: ${pullRequest.user.login}`);
+        console.log(`Date: ${pullRequest.created_at}`);
+        console.log(`${pullRequest.head.ref} --> ${pullRequest.base.ref}`);
+        logText(`\n    ${pullRequest.title}\n`, { bold: true });
+
+    } catch (error) {   
+        if (error instanceof NoGitRepoError) {
+            logError(error.message);
+            process.exit(1);
+        }
+
+        if (error instanceof InvalidRemoteUrlError) {
+            logError(error.message);
+            process.exit(1);
+        }
+
+        if (error instanceof Error) {
+            logError(error.message);
+            process.exit(1);
+        }
+
+        throw error;
+    }
 }
 
 export default getCommand

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import listCommand from "./commands/list.js";
 import createCommand from "./commands/create.js";
-import getCommand from "./commands/get.ts";
+import getCommand from "./commands/get.js";
 import { authCommand, AuthOptions } from "./commands/auth.js";
 
 const program = new Command('pr');   
@@ -31,8 +31,9 @@ program
 program 
     .command('get')
     .description('Get a pull request')
-    .action(() => {
-        getCommand();
+    .argument('<number>', 'Pull request number')
+    .action((pullNumber: number) => {
+        getCommand(pullNumber);
     })
 
 // Auth command

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -64,4 +64,9 @@ export class GithubService {
             body: JSON.stringify({ title, body, head, base })
         })
     }
+
+    // Get a pull request by pull number
+    public getPullRequest(pullNumber: number): Promise<PullRequest> {
+        return this.request<PullRequest>(`${this.repoPath}/pulls/${pullNumber}`, { method: 'GET' })
+    }
 }


### PR DESCRIPTION
Added major logic to getCommand() including the call using GithubService to get a pull request based on the pull number taken as an arg for the 'pr get <number>' command