### PR TITLE
Add commits command and service methods

### DIFF
--- a/src/commands/commits.ts
+++ b/src/commands/commits.ts
@@ -1,9 +1,30 @@
 import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
-import { logError } from "../utils/logger.utils.js";
+import { logError, logWarn } from "../utils/logger.utils.js";
+import { bold } from "../utils/color.utils.js";
 import { GithubService } from "../services/github.service.js";
+import { resolveGitContext } from "../utils/git-context.utils.js";
+import { resolveGithubToken } from "../config/env.js";
 
-async function commitsCommand(): Promise<void> {
+async function commitsCommand(pullNumber: number): Promise<void> {
     try {
+        const context = resolveGitContext();
+        const token = resolveGithubToken();
+        
+        const github = new GithubService({
+            token: token, 
+            owner: context.owner, 
+            repo: context.repo
+        });
+
+        const commits = await github.listPullRequestCommits(pullNumber)
+        
+        console.log(bold(`Pull request #${pullNumber} commits:\n`))
+        for (const commit of commits) {
+            logWarn(`commit ${commit.sha}`)
+            console.log(`Author: ${commit.commit.author.name}`)
+            console.log(`Date: ${new Date(commit.commit.author.date).toUTCString()}\n`) 
+            console.log(`    ${commit.commit.message}\n`)
+        }
 
     } catch (error: unknown) {
         if (error instanceof NoGitRepoError) {
@@ -24,3 +45,5 @@ async function commitsCommand(): Promise<void> {
         throw error;
     }
 }
+
+export default commitsCommand;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import listCommand from "./commands/list.js";
 import createCommand from "./commands/create.js";
 import getCommand from "./commands/get.js";
 import updateCommand from "./commands/update.js";
+import commitsCommand from "./commands/commits.js";
 import { authCommand, AuthOptions } from "./commands/auth.js";
 
 const program = new Command('pr');   
@@ -51,7 +52,7 @@ program
     .description('List commits on a pull request')
     .argument('<pr-number>', 'Pull request number')
     .action((pullNumber: number) => {   
-        
+        commitsCommand(pullNumber);
     })
 
 // Authentication

--- a/src/services/github.service.ts
+++ b/src/services/github.service.ts
@@ -95,10 +95,12 @@ export class GithubService {
         })
     }
 
+    // Get a pull request
     public getPullRequest(pullNumber: number): Promise<PullRequest> {
         return this.request<PullRequest>(`${this.repoPath}/pulls/${pullNumber}`, {method: 'GET'})
     }
 
+    // Update a pull request
     public updatePullRequest(
         pullNumber: number,
         title: string,
@@ -110,6 +112,13 @@ export class GithubService {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json'},
             body: JSON.stringify({ title, body, state, base })
+        })
+    }
+
+    // List commits of a pull request 
+    public listPullRequestCommits(pullNumber: number) {
+        return this.request(`${this.repoPath}/pulls/${pullNumber}/commits`, {
+            method: 'GET'
         })
     }
 }

--- a/src/services/github.service.ts
+++ b/src/services/github.service.ts
@@ -12,6 +12,18 @@ export interface Repository {
     default_branch: string;
 }
 
+export interface Commit {
+    sha: number;
+    commit: {
+        author: {
+            name: string;
+            email: string;
+            date: string;
+        }
+        message: string;
+    }
+}
+
 export interface PullRequest {
     id: number;
     html_url: string;
@@ -116,8 +128,8 @@ export class GithubService {
     }
 
     // List commits of a pull request 
-    public listPullRequestCommits(pullNumber: number) {
-        return this.request(`${this.repoPath}/pulls/${pullNumber}/commits`, {
+    public listPullRequestCommits(pullNumber: number): Promise<Commit[]> {
+        return this.request<Commit[]>(`${this.repoPath}/pulls/${pullNumber}/commits`, {
             method: 'GET'
         })
     }


### PR DESCRIPTION
Declared 'pr commits' command in index.ts cli entry with pr number argument. Added a commitsCommand command function listing all commits for the chosen pull request. Added a listPullRequestCommits method to GithubService class allowing us to interact with the github api to get commits