### PR TITLE
Update pr list command with new options (state and sort)

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -2,11 +2,25 @@ import { resolveGithubToken } from "../config/env.js";
 import { resolveGitContext } from "../utils/git-context.utils.js";
 import { GithubService } from "../services/github.service.js";
 import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
-import { logError, logInfo } from "../utils/logger.utils.js";
-import { warn, bold, dim, success } from "../utils/color.utils.js";
+import { logError } from "../utils/logger.utils.js";
+import { warn, bold, dim, success, error} from "../utils/color.utils.js";
+import { PullRequest } from "../services/github.types.js";
 
-async function listCommand(): Promise<void> {
+export interface ListOptions {
+    all?: boolean;
+    state?: 'open' | 'closed';
+    sort?: 'created' | 'updated' | 'popularity' | 'long-running';
+}
+
+export async function listCommand(options: ListOptions): Promise<void> {
+    let pullRequests: PullRequest[];    
+    let mergeStatus: string;
+
     try {
+        if (options.all && options.state) {
+            throw new Error('You cannot use the --all (-a) flag with the --state flag when running pr list');
+        }
+
         const { owner, repo } = resolveGitContext();    
         const token = resolveGithubToken();
         
@@ -16,19 +30,28 @@ async function listCommand(): Promise<void> {
             repo: repo
         });
 
-        const pullRequests = await github.listPullRequests();
+        if (options.all) {
+            pullRequests = await github.listPullRequests('all', options.sort);
+        } else {
+            pullRequests = await github.listPullRequests(options.state, options.sort);
+        } 
 
         if (pullRequests.length === 0) {
-            console.log('No Open Pull Requests')
+            console.log('No Pull Requests')
         }
         
         for (const pullRequest of pullRequests) {
-            const mergeStatus = pullRequest.merged ? success('Merged') : warn('Pending Merge');
-            const state = pullRequest.state === 'open' ? success('OPEN') : dim('CLOSED');
+            mergeStatus = pullRequest.merged_at ? success('Merged') : warn('Pending Merge');
+
+            if (pullRequest.state === 'closed' && !pullRequest.merged_at) {
+                mergeStatus = error('Not Merged');
+            }
+
+            const state = pullRequest.state === 'open' ? 'OPEN' : dim('CLOSED');
 
             // Header
             console.log(
-                bold(`PR #${pullRequest.number}`),
+                bold(`\nPR #${pullRequest.number}`),
                 state,
                 pullRequest.html_url
             );
@@ -76,5 +99,3 @@ async function listCommand(): Promise<void> {
         throw error;
     }
 }
-
-export default listCommand;

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -2,8 +2,8 @@ import { resolveGithubToken } from "../config/env.js";
 import { resolveGitContext } from "../utils/git-context.utils.js";
 import { GithubService } from "../services/github.service.js";
 import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
-import { logError } from "../utils/logger.utils.js";
-import {warn, bold, dim, success } from "../utils/color.utils.js";
+import { logError, logInfo } from "../utils/logger.utils.js";
+import { warn, bold, dim, success } from "../utils/color.utils.js";
 
 async function listCommand(): Promise<void> {
     try {
@@ -17,6 +17,10 @@ async function listCommand(): Promise<void> {
         });
 
         const pullRequests = await github.listPullRequests();
+
+        if (pullRequests.length === 0) {
+            console.log('No Open Pull Requests')
+        }
         
         for (const pullRequest of pullRequests) {
             const mergeStatus = pullRequest.merged ? success('Merged') : warn('Pending Merge');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import listCommand from "./commands/list.js";
+import { listCommand, ListOptions } from "./commands/list.js";
 import createCommand from "./commands/create.js";
 import getCommand from "./commands/get.js";
 import updateCommand from "./commands/update.js";
@@ -27,9 +27,12 @@ program
 program
     .command('list')
     .description('List pull requests')
+    .option('-a, --all', 'List all pull requests')
+    .option('--state [state]', 'State of pull request (open / closed)')
+    .option('--sort [sort]', "Sort pull requests by either 'created', 'updated', 'popularity' or 'long-running'")
     .helpGroup(coreGroup)
-    .action(() => {
-        listCommand();
+    .action((options: ListOptions) => {
+        listCommand(options);
     })
 
 program

--- a/src/services/github.service.ts
+++ b/src/services/github.service.ts
@@ -13,6 +13,8 @@ interface GithubServiceConfig {
 }
 
 type ResponseMode = 'json' | 'status';
+type PullRequestState = 'open' | 'closed' | 'all';
+type PullRequestSort = 'created' | 'updated' | 'popularity' | 'long-running'
 
 export class GithubService {
     private readonly baseUrl: string;
@@ -63,8 +65,13 @@ export class GithubService {
     }
 
     // List pull requests
-    public listPullRequests(): Promise<PullRequest[]> {
-        return this.request<PullRequest[]>(`${this.repoPath}/pulls`, {method: 'GET'});
+    public listPullRequests(
+        state: PullRequestState = 'open',
+        sort: PullRequestSort = 'created'
+    ): Promise<PullRequest[]> {
+        return this.request<PullRequest[]>(`${this.repoPath}/pulls?state=${state}&sort=${sort}`, {
+            method: 'GET',
+        });
     }
 
     // Create a pull request

--- a/src/services/github.types.ts
+++ b/src/services/github.types.ts
@@ -42,6 +42,7 @@ export interface PullRequest {
     user: User;
     body?: string;
     created_at: string;
+    merged_at?: string;
     head: {
         ref: string;
     }


### PR DESCRIPTION
Added there new options (--all, --state, --sort) allowing the user to customise how then can list all of the pull requests. this also now allows them to see closed pull requests. Fixed a bug regarding the mergeStatus of each pull request updating how accrurate they are