### PR TITLE
Fix merge method option on pr merge

### DIFF
--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -6,7 +6,7 @@ import { logError, logInfo, logSuccess } from "../utils/logger.utils.js";
 import { prompt } from "../utils/prompt.utils.js";
 
 export interface MergeOptions {
-    mergeMethod?: 'merge' | 'squash' | 'rebase';
+    method?: 'merge' | 'squash' | 'rebase';
 }
 
 export async function mergeCommand(pullNumber: number, options: MergeOptions): Promise<void> {
@@ -45,7 +45,7 @@ export async function mergeCommand(pullNumber: number, options: MergeOptions): P
             process.exit(1);
         }
 
-        await github.mergePullRequest(pullNumber, options.mergeMethod);
+        await github.mergePullRequest(pullNumber, options.method);
         logSuccess(`Pull Request #${pullNumber} successfully merged`);
     } catch (error: unknown) {
         if (error instanceof NoGitRepoError) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ program
 program
     .command('merge')
     .description('Merge a pull request')
-    .option('-m, --method [merge-method]', 'Merge method')
+    .option('-m, --method [merge-method]', 'Merge method (merge / squash / rebase)')
     .helpGroup(actionGroup)
     .argument('<pr-number>', 'Pull request number')
     .action((pullNumber: number, options: MergeOptions) => {

--- a/src/services/github.service.ts
+++ b/src/services/github.service.ts
@@ -15,7 +15,7 @@ interface GithubServiceConfig {
 type ResponseMode = 'json' | 'status';
 type PullRequestState = 'open' | 'closed' | 'all';
 type PullRequestSort = 'created' | 'updated' | 'popularity' | 'long-running';
-type MergeMethod = 'merge' | 'squash' | 'rebase' | undefined;
+type MergeMethod = 'merge' | 'squash' | 'rebase';
 
 export class GithubService {
     private readonly baseUrl: string;
@@ -142,7 +142,7 @@ export class GithubService {
     // Merge a pull request
     public mergePullRequest(
         pullNumber: number, 
-        mergeMethod: MergeMethod
+        mergeMethod: MergeMethod = 'merge'
     ) {
         return this.request<number>(`${this.repoPath}/pulls/${pullNumber}/merge`, {
             method: 'PUT',


### PR DESCRIPTION
Updated merge.ts to update MergeMethod interface to match name of option. Updated help description for --method option stating all methods