### PR TITLE
Update global errors location and add new TokenExpiredError class

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,5 +1,5 @@
 import { saveConfig, clearConfig } from "../config/config.js"
-import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js"; 
+import { CLIError } from "../errors/errors.js"; 
 import { logError, logSuccess, logInfo } from "../utils/logger.utils.js";
 import { prompt } from "../utils/prompt.utils.js";
 
@@ -18,14 +18,9 @@ export async function authCommand(options: AuthOptions) {
             logSuccess(`Github token for user '${tokenData.username}' authenticated successfully`);
         }
     } catch (error: unknown) {
-        if (error instanceof NoGitRepoError) {
+        if (error instanceof CLIError) {
             logError(error.message);
-            process.exit(1);
-        }
-
-        if (error instanceof InvalidRemoteUrlError) {
-            logError(error.message);
-            process.exit(1);
+            process.exit(error.exitCode);
         }
 
         if (error instanceof Error) {

--- a/src/commands/commits.ts
+++ b/src/commands/commits.ts
@@ -1,4 +1,4 @@
-import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
+import { CLIError } from "../errors/errors.js";
 import { logError, logWarn } from "../utils/logger.utils.js";
 import { bold } from "../utils/color.utils.js";
 import { GithubService } from "../services/github.service.js";
@@ -27,14 +27,9 @@ async function commitsCommand(pullNumber: number): Promise<void> {
         }
 
     } catch (error: unknown) {
-        if (error instanceof NoGitRepoError) {
+        if (error instanceof CLIError) {
             logError(error.message);
-            process.exit(1);
-        }
-
-        if (error instanceof InvalidRemoteUrlError) {
-            logError(error.message);
-            process.exit(1);
+            process.exit(error.exitCode);
         }
 
         if (error instanceof Error) {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -2,7 +2,7 @@ import { resolveGithubToken } from "../config/env.js";
 import { resolveGitContext } from "../utils/git-context.utils.js";
 import { GithubService } from "../services/github.service.js";
 import { prompt } from "../utils/prompt.utils.js";
-import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
+import { CLIError } from "../errors/errors.js";
 import { logError, logSuccess } from "../utils/logger.utils.js";
 
 export interface CreateOptions { 
@@ -44,14 +44,9 @@ export async function createCommand(options: CreateOptions): Promise<void> {
         logSuccess(`\nPull Request #${created.number} for '${repo.name}' created successfully`);
         console.log(created.html_url);
     } catch (error: unknown) {
-        if (error instanceof NoGitRepoError) {
+        if (error instanceof CLIError) {
             logError(error.message);
-            process.exit(1);
-        }
-
-        if (error instanceof InvalidRemoteUrlError) {
-            logError(error.message);
-            process.exit(1);
+            process.exit(error.exitCode);
         }
 
         if (error instanceof Error) {

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,4 +1,4 @@
-import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
+import { CLIError } from "../errors/errors.js";
 import { logError } from "../utils/logger.utils.js";
 import { bold, success, error, dim} from "../utils/color.utils.js";
 import { GithubService } from "../services/github.service.js";
@@ -32,14 +32,9 @@ async function filesCommand(pullNumber: number): Promise<void> {
         }
 
     } catch (error: unknown) {
-        if (error instanceof NoGitRepoError) {
+        if (error instanceof CLIError) {
             logError(error.message);
-            process.exit(1);
-        }
-
-        if (error instanceof InvalidRemoteUrlError) {
-            logError(error.message);
-            process.exit(1);
+            process.exit(error.exitCode);
         }
 
         if (error instanceof Error) {

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -1,4 +1,4 @@
-import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js"
+import { CLIError } from "../errors/errors.js";
 import { logError} from "../utils/logger.utils.js"
 import { warn, bold, dim, success, error } from "../utils/color.utils.js";
 import { GithubService } from "../services/github.service.js";
@@ -64,14 +64,9 @@ async function getCommand(pullNumber: number): Promise<void> {
         }
 
     } catch (error: unknown) {   
-        if (error instanceof NoGitRepoError) {
+        if (error instanceof CLIError) {
             logError(error.message);
-            process.exit(1);
-        }
-
-        if (error instanceof InvalidRemoteUrlError) {
-            logError(error.message);
-            process.exit(1);
+            process.exit(error.exitCode);
         }
 
         if (error instanceof Error) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,7 +1,7 @@
 import { resolveGithubToken } from "../config/env.js";
 import { resolveGitContext } from "../utils/git-context.utils.js";
 import { GithubService } from "../services/github.service.js";
-import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
+import { CLIError } from "../errors/errors.js";
 import { logError } from "../utils/logger.utils.js";
 import { warn, bold, dim, success, error} from "../utils/color.utils.js";
 import { PullRequest } from "../services/github.types.js";
@@ -81,14 +81,9 @@ export async function listCommand(options: ListOptions): Promise<void> {
 
         }
     } catch (error: unknown) {
-        if (error instanceof NoGitRepoError) {
+        if (error instanceof CLIError) {
             logError(error.message);
-            process.exit(1);
-        }
-
-        if (error instanceof InvalidRemoteUrlError) {
-            logError(error.message);
-            process.exit(1);
+            process.exit(error.exitCode);
         }
 
         if (error instanceof Error) {

--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -1,7 +1,7 @@
 import { GithubService } from "../services/github.service.js";
 import { resolveGitContext } from "../utils/git-context.utils.js";
 import { resolveGithubToken } from "../config/env.js";
-import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
+import { CLIError } from "../errors/errors.js";
 import { logError, logInfo, logSuccess } from "../utils/logger.utils.js";
 import { prompt } from "../utils/prompt.utils.js";
 
@@ -48,14 +48,9 @@ export async function mergeCommand(pullNumber: number, options: MergeOptions): P
         await github.mergePullRequest(pullNumber, options.method);
         logSuccess(`Pull Request #${pullNumber} successfully merged`);
     } catch (error: unknown) {
-        if (error instanceof NoGitRepoError) {
+        if (error instanceof CLIError) {
             logError(error.message);
-            process.exit(1);
-        }
-
-        if (error instanceof InvalidRemoteUrlError) {
-            logError(error.message);
-            process.exit(1);
+            process.exit(error.exitCode);
         }
 
         if (error instanceof Error) {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -3,7 +3,7 @@ import { GithubService } from "../services/github.service.js";
 import { resolveGitContext } from "../utils/git-context.utils.js";
 import { logError } from "../utils/logger.utils.js";
 import { success, error } from "../utils/color.utils.js";
-import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
+import { CLIError } from "../errors/errors.js";
 
 async function statusCommand(pullNumber: number) {
     try {
@@ -23,14 +23,9 @@ async function statusCommand(pullNumber: number) {
         console.log(`Merge Status: ${mergeStatus}`);
 
     } catch (error: unknown) {
-        if (error instanceof NoGitRepoError) {
+       if (error instanceof CLIError) {
             logError(error.message);
-            process.exit(1);
-        }
-
-        if (error instanceof InvalidRemoteUrlError) {
-            logError(error.message);
-            process.exit(1);
+            process.exit(error.exitCode);
         }
 
         if (error instanceof Error) {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,7 +1,7 @@
 import { resolveGitContext } from "../utils/git-context.utils.js";
 import { resolveGithubToken } from "../config/env.js";
 import { GithubService } from "../services/github.service.js";
-import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
+import { CLIError } from "../errors/errors.js";
 import { logError, logSuccess } from "../utils/logger.utils.js";
 import { prompt } from "../utils/prompt.utils.js";
 
@@ -26,14 +26,9 @@ async function syncCommand(pullNumber: number) {
         logSuccess('Pull Request branch successfully updated and synced');
 
     } catch (error: unknown) {
-        if (error instanceof NoGitRepoError) {
+        if (error instanceof CLIError) {
             logError(error.message);
-            process.exit(1);
-        }
-
-        if (error instanceof InvalidRemoteUrlError) {
-            logError(error.message);
-            process.exit(1);
+            process.exit(error.exitCode);
         }
 
         if (error instanceof Error) {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -2,7 +2,7 @@ import { resolveGithubToken } from "../config/env.js";
 import { resolveGitContext } from "../utils/git-context.utils.js";
 import { GithubService } from "../services/github.service.js";
 import { prompt } from "../utils/prompt.utils.js";
-import { NoGitRepoError, InvalidRemoteUrlError } from "../utils/git.utils.js";
+import { CLIError } from "../errors/errors.js";
 import { logError, logSuccess } from "../utils/logger.utils.js";
 
 async function updateCommand(pullNumber: number): Promise<void> {
@@ -31,15 +31,11 @@ async function updateCommand(pullNumber: number): Promise<void> {
 
         logSuccess(`Pull Request for '${repo.name}' updated successfully`);
     } catch (error: unknown) {
-        if (error instanceof NoGitRepoError) {
+        if (error instanceof CLIError) {
             logError(error.message);
-            process.exit(1);
+            process.exit(error.exitCode);
         }
 
-        if (error instanceof InvalidRemoteUrlError) {
-            logError(error.message);
-            process.exit(1);
-        }
 
         if (error instanceof Error) {
             switch (error.message) {

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -1,0 +1,30 @@
+export class CLIError extends Error {
+    public readonly exitCode: number;
+
+    constructor(message: string, exitCode: number = 1) {
+        super(message);
+        this.exitCode = exitCode;
+        this.name = 'CLIError'
+    }
+}
+
+export class NoGitRepoError extends CLIError {
+    constructor() {
+        super('Not a git repository');
+        this.name = 'NoGitRepoError';
+    }
+}
+
+export class InvalidRemoteUrlError extends CLIError {
+    constructor() {
+        super('Invalid Remote Git URL');
+        this.name = 'InvalidRemoteUrlError';
+    }
+}
+
+export class TokenExpiredError extends CLIError { 
+    constructor() {
+        super('GitHub Token expired. Please use pr auth to register a new GitHub token');
+        this.name = 'TokenExpiredError'
+    }   
+}

--- a/src/services/github.service.ts
+++ b/src/services/github.service.ts
@@ -1,3 +1,4 @@
+import { TokenExpiredError } from "../errors/errors.js";
 import { PullRequest, User, File, Commit, Repository } from "./github.types.js";
 
 interface CreatePullRequestResponse {
@@ -43,6 +44,10 @@ export class GithubService {
         });
 
         if (mode === 'status') {
+            if (response.status === 401) {
+                throw new TokenExpiredError()
+            }
+            
             return response.status as T;
         }
 

--- a/src/services/github.service.ts
+++ b/src/services/github.service.ts
@@ -156,13 +156,10 @@ export class GithubService {
         pullNumber: number,
         expectedHeadSha: string
     ): Promise<boolean> {
-        const status = await this.request<number>(
-            `${this.repoPath}/pulls/${pullNumber}/update-branch`, 
-            {
+        const status = await this.request<number>(`${this.repoPath}/pulls/${pullNumber}/update-branch`, {
                 method: 'PUT',
                 body: JSON.stringify({ expected_head_sha: expectedHeadSha })
-            },
-            'status'
+            }, 'status'
         )
 
         if (status === 202) {

--- a/src/utils/git.utils.ts
+++ b/src/utils/git.utils.ts
@@ -1,6 +1,5 @@
 import { execSync } from "child_process";
-import { resolveGitContext } from "./git-context.utils.js";
-import { GithubService } from "../services/github.service.js";
+import { NoGitRepoError, InvalidRemoteUrlError } from "../errors/errors.js";
 
 interface ParsedUrlItems {
     owner: string;
@@ -13,19 +12,6 @@ export interface TokenValidationResult {
     username?: string;
 }
 
-export class NoGitRepoError extends Error {
-    constructor() {
-        super('pr: Not a git repository');
-        this.name = 'NoGitRepoError';
-    }
-}
-
-export class InvalidRemoteUrlError extends Error {
-    constructor() {
-        super('pr: Invalid Remote Git URL');
-        this.name = 'InvalidRemoteUrlError';
-    }
-}
 
 export function getCurrentBranch(): string {
     try {


### PR DESCRIPTION
Added an errors dir and errors.ts file that now contains all of the global error classes moving them out of the git utils file. a new global error class has been created for when a users GitHub token expires solving the previous problem of it just logging '401'.