### PR TITLE
Add status option to authentication command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "bin",
     "dist",
+    "src",
     "docs"
   ],
   "scripts": {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,22 +1,33 @@
-import { saveConfig, clearConfig } from "../config/config.js"
+import { loadConfig, saveConfig, clearConfig } from "../config/config.js"
 import { CLIError } from "../errors/errors.js"; 
 import { logError, logSuccess, logInfo } from "../utils/logger.utils.js";
 import { prompt } from "../utils/prompt.utils.js";
 
 export interface AuthOptions{
     delete?: boolean
+    status?: boolean
 }
 
 export async function authCommand(options: AuthOptions) {
     try {
         if (options.delete) {
             clearConfig();
-            logInfo("Config cleared. See 'pr auth -h' for config options")
-        } else {
-            const token = await prompt('Github Token> ')
-            const tokenData = await saveConfig(token);
-            logSuccess(`Github token for user '${tokenData.username}' authenticated successfully`);
+            logInfo("Github token deleted and config cleared. Use 'pr auth -h' for auth options")
+            process.exit(1);
         }
+
+        if (options.status) {
+            const isAuthenticated = loadConfig() ? true : false;
+            isAuthenticated 
+                ? logSuccess('GitHub token authenticated and stored in config file') 
+                : logError(`GitHub token not authenticated. Use 'pr auth -h' for auth options`)
+            process.exit(1)
+        }
+
+        const token = await prompt('Github Token> ')
+        const tokenData = await saveConfig(token);
+        logSuccess(`Github token for user '${tokenData.username}' authenticated successfully`);
+     
     } catch (error: unknown) {
         if (error instanceof CLIError) {
             logError(error.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const program = new Command('pr');
 // Core pull request operations
 program 
     .description('A cli tool that allows users to create and manage pull requests')
-    .version('1.0.4')
+    .version('1.4.0')
     .action(() => {
         program.outputHelp();
     })
@@ -119,6 +119,7 @@ program
     .command('auth')
     .description('Authenticate GitHub Token (Required)')
     .helpGroup('Authentication / Login')
+    .option('-s, --status', 'Check authentication status')
     .option('-d, --delete', 'Delete GitHub token from config')
     .action((options: AuthOptions) => {
         authCommand(options);


### PR DESCRIPTION
Added -s --status option to pr auth command allowing users to see if they currently have an authenticated Github token.